### PR TITLE
Use Response Facade instead of Illuminate\Http\Response

### DIFF
--- a/src/Controllers/AbstractApiController.php
+++ b/src/Controllers/AbstractApiController.php
@@ -4,12 +4,12 @@ namespace Arrounded\Controllers;
 use Arrounded\Abstracts\AbstractRepository;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Contracts\ArrayableInterface;
 use Illuminate\Support\Str;
+use Response;
 
 abstract class AbstractApiController extends Controller
 {


### PR DESCRIPTION
The Response Facade is the class that has the JSON() method, using Illuminate\Http\Response you will get an error saying it can not be found.
