### PR TITLE
Collection: replace array_map with foreach to preserve source array keys.

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -85,9 +85,14 @@ class Collection extends \Illuminate\Database\Eloquent\Collection
 	 */
 	public function counts()
 	{
-		return $this->map(function ($entries) {
-			return sizeof($entries);
-		});
+		// do not modify the source collection
+		$self = clone $this;
+
+		foreach ($self->items as &$item) {
+			$item = sizeof($item);
+		}
+
+		return $self;
 	}
 
 	/**


### PR DESCRIPTION
When passing 2 arguments to array_map (done by Illuminate\Support\Collection)
the array keys are not preserved. For the counts functionality this is required.

@see http://www.php.net/manual/en/function.array-map.php#example-5055
