### PR TITLE
Cannot remove item from Jsonable Array

### DIFF
--- a/tests/Dummies/DummyJsonModel.php
+++ b/tests/Dummies/DummyJsonModel.php
@@ -29,4 +29,14 @@ class DummyJsonModel extends DummyModel
 	{
 		$this->setJsonAttribute('schedule', $schedule);
 	}
+
+	public function getServicesAttribute()
+	{
+		return $this->getJsonAttribute('services');
+	}
+
+	public function setServicesAttribute($services)
+	{
+		$this->setJsonAttribute('services', $services);
+	}
 }

--- a/tests/Traits/JsonAttributesTest.php
+++ b/tests/Traits/JsonAttributesTest.php
@@ -40,4 +40,16 @@ class JsonAttributesTest extends ArroundedTestCase
 
 		$this->assertFalse($model->notifications['foo']);
 	}
+
+	public function testCanRemovePreviousValues()
+	{
+		$model = new DummyJsonModel();
+		$model->setServicesAttribute(['twitter', 'facebook', 'pinterest', 'tumblr', 'linkedin']);
+
+		$this->assertEquals(['twitter', 'facebook', 'pinterest', 'tumblr', 'linkedin'], $model->services);
+
+		$model->setServicesAttribute(['twitter', 'facebook', 'pinterest', 'tumblr']);
+		$this->assertEquals(['twitter', 'facebook', 'pinterest', 'tumblr'], $model->services);
+	}
+
 }


### PR DESCRIPTION
I included a failing test to indicate what I mean.

If you have a json attribute which stores an array of items, and at some point want to remove an item. It will still include the item you removed.

```php
$user->services;
// ['twitter', 'facebook', 'pinterest', 'tumblr', 'linkedin'];

$user->services  = ['twitter', 'facebook', 'pinterest', 'tumblr'];

$user->services;
// I expect it to be:
// ['twitter', 'facebook', 'pinterest', 'tumblr'];

// But it returns: 
// ['twitter', 'facebook', 'pinterest', 'tumblr', 'linkedin'];
```

The issue lies with the `array_replace_recursive($defaults, $value);` because it only replaces or adds stuff, not remove.

You can fix it by removing the defaults in `setJsonAttribute` so it becomes this:

```
$value    = (array) $value;
$value    = json_encode($value);

$this->attributes[$attribute] = $value;
```

But that is a big change, although I'm not sure how many people use the defaults in the setter instead of the getter.
