### PR TITLE
Only retrieve data from related table when using a BelongsToMany

### DIFF
--- a/src/Abstracts/AbstractRepository.php
+++ b/src/Abstracts/AbstractRepository.php
@@ -290,9 +290,15 @@ abstract class AbstractRepository implements RepositoryInterface
 	 */
 	protected function findFromQuery($query, $item)
 	{
+		$columns = null;
+
 		// If we have an instance already, return it
 		if ($item instanceof Model) {
 			return $item;
+		}
+
+		if ($this->items instanceof BelongsToMany) {
+			$columns = [$this->items->getRelated()->getTable() . '.*'];
 		}
 
 		// Find by slug
@@ -302,7 +308,7 @@ abstract class AbstractRepository implements RepositoryInterface
 			}
 		}
 
-		return $query->findOrFail($item);
+		return $query->findOrFail($item, $columns);
 	}
 
 	/**

--- a/tests/Abstracts/AbstractRepositoryTest.php
+++ b/tests/Abstracts/AbstractRepositoryTest.php
@@ -25,7 +25,7 @@ class AbstractRepositoryTest extends ArroundedTestCase
 	public function testCanFindItem()
 	{
 		$eloquent = Mockery::mock('Eloquent', function ($mock) {
-			$mock->shouldReceive('findOrFail')->once()->with(1)->andReturn('Model1');
+			$mock->shouldReceive('findOrFail')->once()->with(1, null)->andReturn('Model1');
 		});
 
 		$repository = new DummyRepository($eloquent);
@@ -44,7 +44,7 @@ class AbstractRepositoryTest extends ArroundedTestCase
 	public function testCanFindItemViaAttributes()
 	{
 		$eloquent   = Mockery::mock('Eloquent', function ($mock) {
-			$mock->shouldReceive('findOrFail')->once()->with(1)->andReturn(new DummyModel());
+			$mock->shouldReceive('findOrFail')->once()->with(1, null)->andReturn(new DummyModel());
 		});
 		$repository = new DummyRepository($eloquent);
 		$model      = $repository->findOrNew(array('id' => 1, 'name' => 'foo'));
@@ -67,7 +67,7 @@ class AbstractRepositoryTest extends ArroundedTestCase
 	{
 		$eloquent   = Mockery::mock('Eloquent', function ($mock) {
 			$mock->shouldReceive('create')->once()->with(array('name' => 'foo'))->andReturn(new DummyModel(array('id' => 1)));
-			$mock->shouldReceive('findOrFail')->once()->with(1)->andReturn(new DummyModel(array('name' => 'foo')));
+			$mock->shouldReceive('findOrFail')->once()->with(1, null)->andReturn(new DummyModel(array('name' => 'foo')));
 		});
 		$repository = new DummyRepository($eloquent);
 		$model      = $repository->create(array('name' => 'foo'));
@@ -83,7 +83,7 @@ class AbstractRepositoryTest extends ArroundedTestCase
 		});
 
 		$eloquent = Mockery::mock('Eloquent', function ($mock) use ($model) {
-			$mock->shouldReceive('findOrFail')->once()->with(1)->andReturn($model);
+			$mock->shouldReceive('findOrFail')->once()->with(1, null)->andReturn($model);
 		});
 
 		$repository = new DummyRepository($eloquent);
@@ -100,7 +100,7 @@ class AbstractRepositoryTest extends ArroundedTestCase
 		$eloquent = Mockery::mock('Eloquent', function ($mock) use ($model) {
 			$mock
 				->shouldReceive('hasTrait')->andReturn(false)
-				->shouldReceive('findOrFail')->once()->with(1)->andReturn($model);
+				->shouldReceive('findOrFail')->once()->with(1, null)->andReturn($model);
 		});
 
 		$repository = new DummyRepository($eloquent);


### PR DESCRIPTION
I was having a problem using the `find` method when using a `BelongsToMany` relationship. I would do the following in a controller:

``` php
public function __construct(GamesRepository $repository)
{
        $this->repository  = $repository;
                // I only want the games of the current users to be available
        $this->repository->setItems(Auth::user()->student->games());
}
```

Then further down I'd do 

``` php
$game = $this->repository->find(1);
var_dump($game->id); // Would return 4
```

Turns out the following query is executed:

``` sql
select * from `games` inner join `game_player` on `games`.`id` = `game_player`.`game_id` where `game_player`.`player_id` = 1 and `games`.`id` = '1'
```

Which returns the following result:

``` sql
id  company_id  status  actions_in_play actions_market  created_at  updated_at  id  game_id player_id   score   budget  actions
1   2   invitation  NULL    NULL    2014-12-11 08:13:34 2014-12-11 08:13:34 7   4   4   0   40  NULL
```

What this PR does is check if the `$items` is an instance of `BelongsToMany` and if so it will select only the columns from the relation  table, eg: `games.*`
