### PR TITLE
fix delete updates keeps a few styles files

### DIFF
--- a/src/Abstracts/Models/AbstractUploadModel.php
+++ b/src/Abstracts/Models/AbstractUploadModel.php
@@ -39,7 +39,7 @@ abstract class AbstractUploadModel extends AbstractModel implements StaplerableI
      */
     public function __construct(array $attributes = [])
     {
-        $this->hasAttachedFile('file');
+        $this->hasAttachedFile('file', ['styles' => $this->getThumbnailsConfiguration()]);
 
         parent::__construct($attributes);
     }


### PR DESCRIPTION
Deleting uploads was leaving some trash behind, it was only deleting the `original` style, followed stapler convention:

```
    public function __construct(array $attributes = array()) {
        $this->hasAttachedFile('avatar', [
            'styles' => [
                'medium' => '300x300',
                'thumb' => '100x100'
            ]
        ]);

        parent::__construct($attributes);
    }
```