### PR TITLE
Load S3 configuration for stapler

### DIFF
--- a/src/Abstracts/Models/AbstractUploadModel.php
+++ b/src/Abstracts/Models/AbstractUploadModel.php
@@ -171,6 +171,7 @@ abstract class AbstractUploadModel extends AbstractModel implements StaplerableI
         // Get base configuration
         $config = Config::get('laravel-stapler::stapler');
         $config += Config::get('laravel-stapler::filesystem');
+        $config += Config::get('laravel-stapler::s3');
 
         // Set styles
         $config['styles']             = $this->getThumbnailsConfiguration();


### PR DESCRIPTION
### Fixed

* `AbstractUploadModel` wasn't including the S3 settings in the config.