### PR TITLE
Validation Contract

### DIFF
--- a/src/Abstracts/AbstractForm.php
+++ b/src/Abstracts/AbstractForm.php
@@ -1,7 +1,7 @@
 <?php
 namespace Arrounded\Abstracts;
 
-use Arrounded\Abstracts\Models\AbstractModel;
+use Arrounded\Interfaces\ValidatableInterface;
 use Arrounded\Validation\ValidationException;
 use Dingo\Api\Exception\ResourceException;
 use Illuminate\Support\Facades\Request;
@@ -36,9 +36,9 @@ abstract class AbstractForm
     protected $messages = [];
 
     /**
-     * A model to fine-tune rules to.
+     * An object to fine-tune rules to.
      *
-     * @type AbstractModel
+     * @type ValidatableInterface
      */
     protected $model;
 
@@ -92,7 +92,7 @@ abstract class AbstractForm
     /**
      * Validate an array of attributes for a particular model.
      *
-     * @param AbstractModel      $model
+     * @param ValidatableInterface $model
      * @param ParameterBag|array $attributes
      * @param callable|null      $callback
      *
@@ -100,7 +100,7 @@ abstract class AbstractForm
      *
      * @return mixed
      */
-    public function validateFor(AbstractModel $model, $attributes = [], callable $callback = null)
+    public function validateFor(ValidatableInterface $model, $attributes = [], callable $callback = null)
     {
         $this->model = $model;
 

--- a/src/Abstracts/Models/AbstractModel.php
+++ b/src/Abstracts/Models/AbstractModel.php
@@ -4,8 +4,9 @@ namespace Arrounded\Abstracts\Models;
 use Arrounded\Collection;
 use Arrounded\Traits\Reflection\ReflectionModel;
 use Illuminate\Database\Eloquent\Model;
+use Arrounded\Interfaces\ValidatableInterface;
 
-abstract class AbstractModel extends Model
+abstract class AbstractModel extends Model implements ValidatableInterface
 {
     use ReflectionModel;
 

--- a/src/Interfaces/ValidatableInterface.php
+++ b/src/Interfaces/ValidatableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Arrounded\Interfaces;
+
+interface ValidatableInterface
+{
+
+}


### PR DESCRIPTION
### Changed

* Use a `ValidatableInterface` instead of `AbstractModel` in `AbstractForm::validateFor` ( #23 )

---

Allows you to switch the underlying model and still use the `AbstractForm`

Made the PR to master since develop is L5+ only