### PR TITLE
fixes to the 0.5.x

### DIFF
--- a/src/Abstracts/AbstractFinder.php
+++ b/src/Abstracts/AbstractFinder.php
@@ -274,7 +274,10 @@ abstract class AbstractFinder
      */
     protected function scopeSearchOnField(Builder &$query, $field, $value, $or = true)
     {
-        return $query->where($field, 'LIKE', $this->formatValue($value))->orWhere($field, $value);
+        return $query->where(function($query) use ($field, $value) {
+            $query->where($field, $value)
+                ->orWhere($field, 'LIKE', $this->formatValue($value));
+        });
     }
 
     //////////////////////////////////////////////////////////////////////

--- a/src/Abstracts/AbstractFinder.php
+++ b/src/Abstracts/AbstractFinder.php
@@ -155,7 +155,7 @@ abstract class AbstractFinder
         // Filter input
         $attributes = [];
         foreach ($search as $name => $value) {
-            if ($value && $this->isSearchable($name)) {
+            if ($this->isSearchable($name) && $value !== '') {
                 $attributes[$name] = $value;
             }
         }

--- a/views/_partials/admin/index.twig
+++ b/views/_partials/admin/index.twig
@@ -7,7 +7,7 @@
 {% endif %}
 
 {# Search form #}
-{% if Route.has("#{resource}.search") and items.links() and searchable is not empty %}
+{% if Route.has("#{resource}.search") and items.links() and (searchable is not empty or has_custom_search_fields) %}
 	<h4 class="text-center" ng-init="showSearch = {{ Input.has('id') ? 'true' : 'false' }}" ng-click="showSearch = !showSearch">
 		<a href="#">Search</a>
 	</h4>
@@ -16,6 +16,7 @@
 		{% for field in searchable %}
 			{{ Former.text(field)|raw }}
 		{% endfor %}
+		{% block custom_search_fields %}{% endblock %}
 		{{ Former.actions().large_primary_submit('Search')|raw }}
 		{{ Former.close()|raw }}
 	</div>

--- a/views/_partials/admin/pagination.twig
+++ b/views/_partials/admin/pagination.twig
@@ -1,7 +1,7 @@
 <nav id="pagination" class="row text-center">
 	{# Paginated in the backend. #}
 	{% if items.links() %}
-		{{ items.links()|raw }}
+		{{ items.appends(Input.except('page')).links()|raw }}
 
 		{# Paginate via JS. #}
 	{% elseif items.count() > 20 %}


### PR DESCRIPTION
### Added

- allow passing `custom_search_fields` to the search form on the admin/index page

### Changed
- pass query strings to the pagination links
- grouping `orWhere` clauses into a single statement

### Fixed
- fixed the `AbstractFinder` to allow searching for boolean fields or numeric fields