### PR TITLE
Recursive merge for JS bridge

### DIFF
--- a/src/Assets/JavascriptBridge.php
+++ b/src/Assets/JavascriptBridge.php
@@ -23,7 +23,7 @@ class JavascriptBridge
         $data = array_filter($data, function ($value) {
             return !is_null($value);
         });
-        $data = array_merge(static::$data, $data);
+        $data = array_merge_recursive(static::$data, $data);
 
         static::$data = $data;
     }


### PR DESCRIPTION
Since using Redux I've been running into issues with keeping the `__STATE__` correct.

Use-case:

I have a `LayoutComposer` that is triggered on a `layouts.global` render that contains this code:

``` php
JavascriptBridge::add([
    'route' => Route::getCurrentRoute()->getName(),
    '__STATE__' => [
        'errors' => $view->errors->toArray(),
        'old' => Input::old(),
    ],
]);
```

Then in a composer for a specific app:

``` php

JavascriptBridge::add([
    'route' => Route::getCurrentRoute()->getName(),
    '__STATE__' => [
        'app' => [
            'some',
            'app',
            'state',
        ]
    ],
]);
```

The issue currently is that the entire `__STATE__` is replaced by the global composer. By recursively merging this is solved.
